### PR TITLE
matomo site migrations are a bit tricky..

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -33,11 +33,11 @@
   (function() {
     var u="//matomo.puzzle.ch/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 2]);
+    _paq.push(['setSiteId', 5]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="//matomo.puzzle.ch/piwik.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="//matomo.puzzle.ch/piwik.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
   </body>
 </html>


### PR DESCRIPTION
Several migrations can not be merged by the target matomo database. Therefore a new site for the second appuio.ch dump was generated and I had to update the statistics link once again.